### PR TITLE
Fix GitHub Pages deployment by enabling Pages automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Setup Pages
         id: setup_pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The configure-pages action was failing with "Get Pages site failed" because
GitHub Pages was not enabled on the repository. Adding enablement: true lets
the action auto-enable Pages instead of requiring manual setup first.

https://claude.ai/code/session_01K7MSZTdUJ6NSKDUr5sZDW9