### PR TITLE
Fix GitHub Pages deployment by removing enablement: true from configure-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Setup Pages
         id: setup_pages
         uses: actions/configure-pages@v4
-        with:
-          enablement: true
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The enablement option in actions/configure-pages@v4 attempts to
programmatically enable GitHub Pages via the API, which requires
admin-level repository permissions. The default GITHUB_TOKEN does not
have admin access, causing "Resource not accessible by integration".

Pages must be enabled manually in Settings > Pages > Source > GitHub
Actions (as documented in the workflow prerequisites).

https://claude.ai/code/session_01T2H7RYrwDQxkmp9oWpuQks