### PR TITLE
Remove burgers, make category nav sticky with scroll-to-section

### DIFF
--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -171,46 +171,9 @@ export const hardcodedMenu: Category[] = [
     ],
   },
   {
-    id: "cat-mesainiai",
-    name: "Mėsainiai",
-    sort_order: 3,
-    products: [
-      {
-        id: "prod-mesainis-vistiena",
-        category_id: "cat-mesainiai",
-        name: "Mėsainis su vištiena",
-        description: "Mėsainis su vištienos kotletu.",
-        base_price: 400,
-        image_url: "https://images.unsplash.com/photo-1568901346375-23c9450f58cd?w=200&h=200&fit=crop",
-        is_available: true,
-        dietary_tags: [],
-      },
-      {
-        id: "prod-mesainis-jautiena",
-        category_id: "cat-mesainiai",
-        name: "Mėsainis su jautiena",
-        description: "Mėsainis su jautienos kotletu.",
-        base_price: 500,
-        image_url: "https://images.unsplash.com/photo-1550547660-d9450f859349?w=200&h=200&fit=crop",
-        is_available: true,
-        dietary_tags: [],
-      },
-      {
-        id: "prod-mesainis-vegetariskas",
-        category_id: "cat-mesainiai",
-        name: "Vegetariškas mėsainis",
-        description: "Mėsainis su daržovių kotletu.",
-        base_price: 500,
-        image_url: "https://images.unsplash.com/photo-1568901346375-23c9450f58cd?w=200&h=200&fit=crop",
-        is_available: true,
-        dietary_tags: ["vegetariškas"],
-      },
-    ],
-  },
-  {
     id: "cat-kiti-patiekalai",
     name: "Kiti patiekalai",
-    sort_order: 4,
+    sort_order: 3,
     products: [
       {
         id: "prod-vistienos-kepsneliai",
@@ -307,7 +270,7 @@ export const hardcodedMenu: Category[] = [
   {
     id: "cat-gerimai",
     name: "Gėrimai",
-    sort_order: 5,
+    sort_order: 4,
     products: [
       {
         id: "prod-coca-cola",

--- a/src/features/menu/category-filter.tsx
+++ b/src/features/menu/category-filter.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 interface CategoryFilterProps {
   categories: { id: string; name: string }[];
   activeId: string | null;
-  onSelect: (id: string | null) => void;
+  onSelect: (id: string) => void;
 }
 
 export function CategoryFilter({
@@ -13,22 +14,29 @@ export function CategoryFilter({
   activeId,
   onSelect,
 }: CategoryFilterProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  // Auto-scroll the active pill into view
+  useEffect(() => {
+    if (!activeId) return;
+    const btn = buttonRefs.current.get(activeId);
+    if (btn && containerRef.current) {
+      btn.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+    }
+  }, [activeId]);
+
   return (
-    <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
-      <button
-        onClick={() => onSelect(null)}
-        className={cn(
-          "shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors",
-          activeId === null
-            ? "bg-orange-600 text-white"
-            : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-        )}
-      >
-        Visi
-      </button>
+    <div
+      ref={containerRef}
+      className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide"
+    >
       {categories.map((cat) => (
         <button
           key={cat.id}
+          ref={(el) => {
+            if (el) buttonRefs.current.set(cat.id, el);
+          }}
           onClick={() => onSelect(cat.id)}
           className={cn(
             "shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors",

--- a/supabase/migrations/002_seed_data.sql
+++ b/supabase/migrations/002_seed_data.sql
@@ -2,9 +2,8 @@
 INSERT INTO categories (id, name, sort_order) VALUES
   ('a1000000-0000-0000-0000-000000000001', 'Picos', 1),
   ('a1000000-0000-0000-0000-000000000002', 'Kebabai', 2),
-  ('a1000000-0000-0000-0000-000000000003', 'Mėsainiai', 3),
-  ('a1000000-0000-0000-0000-000000000004', 'Kiti patiekalai', 4),
-  ('a1000000-0000-0000-0000-000000000005', 'Gėrimai', 5);
+  ('a1000000-0000-0000-0000-000000000004', 'Kiti patiekalai', 3),
+  ('a1000000-0000-0000-0000-000000000005', 'Gėrimai', 4);
 
 -- Seed products: Picos
 INSERT INTO products (id, category_id, name, description, base_price, is_available, dietary_tags) VALUES
@@ -26,12 +25,6 @@ INSERT INTO products (id, category_id, name, description, base_price, is_availab
   ('b1000000-0000-0000-0000-000000000013', 'a1000000-0000-0000-0000-000000000002', 'Kebabas lavašė su jautiena (didelis)', 'Didelis kebabas lavašė su jautiena, salotomis ir padažu.', 700, true, '{}'),
   ('b1000000-0000-0000-0000-000000000014', 'a1000000-0000-0000-0000-000000000002', 'Kebabas lėkštėje su vištiena', 'Kebabas lėkštėje su vištiena, salotomis ir padažu.', 600, true, '{}'),
   ('b1000000-0000-0000-0000-000000000015', 'a1000000-0000-0000-0000-000000000002', 'Kebabas lėkštėje su jautiena', 'Kebabas lėkštėje su jautiena, salotomis ir padažu.', 700, true, '{}');
-
--- Seed products: Mėsainiai
-INSERT INTO products (id, category_id, name, description, base_price, is_available, dietary_tags) VALUES
-  ('b1000000-0000-0000-0000-000000000040', 'a1000000-0000-0000-0000-000000000003', 'Mėsainis su vištiena', 'Mėsainis su vištienos kotletu.', 400, true, '{}'),
-  ('b1000000-0000-0000-0000-000000000041', 'a1000000-0000-0000-0000-000000000003', 'Mėsainis su jautiena', 'Mėsainis su jautienos kotletu.', 500, true, '{}'),
-  ('b1000000-0000-0000-0000-000000000042', 'a1000000-0000-0000-0000-000000000003', 'Vegetariškas mėsainis', 'Mėsainis su daržovių kotletu.', 500, true, '{"vegetariškas"}');
 
 -- Seed products: Kiti patiekalai
 INSERT INTO products (id, category_id, name, description, base_price, is_available, dietary_tags) VALUES


### PR DESCRIPTION
- Remove Mėsainiai (burgers) category from hardcoded menu and seed data
- Replace category filter with sticky navigation bar below navbar
- Click a category pill to smooth-scroll to that section instead of filtering
- Track active category via IntersectionObserver as user scrolls
- Auto-scroll active pill into view in the horizontal category bar

https://claude.ai/code/session_01Dif4fQU9bDonkHQA3NKfD9