### PR TITLE
Fix GitHub Actions: exclude unit tests from Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  testIgnore: ["**/unit/**"],
   baseURL: "http://localhost:3000",
   use: {
     viewport: { width: 390, height: 844 },


### PR DESCRIPTION
## Summary
- The Playwright config had `testDir: "./tests"` which caused it to scan all subdirectories, including `tests/unit/` containing Vitest unit tests
- This made the "UI Tests (Playwright)" CI job fail with `Vitest cannot be imported in a CommonJS module using require()` errors
- Added `testIgnore: ["**/unit/**"]` to `playwright.config.ts` so Playwright only runs its own `.spec.ts` files

## Test plan
- [x] `npm run build` passes locally
- [ ] CI workflow passes on this PR (unit tests + Playwright jobs both green)

https://claude.ai/code/session_0152uQsdFuvW7s7Njowcbkih